### PR TITLE
change picard version 2.8.3 to 2.15.0

### DIFF
--- a/tools/picard_collectrawwgsmetrics.cwl
+++ b/tools/picard_collectrawwgsmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.8.3'
+    dockerPull: 'kfdrc/picard:2.15.0'
 baseCommand: [ java, '-Xms2000m', '-jar', /picard.jar, CollectRawWgsMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectwgsmetrics.cwl
+++ b/tools/picard_collectwgsmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.8.3'
+    dockerPull: 'kfdrc/picard:2.15.0'
 baseCommand: [ java, '-Xms2000m', '-jar', /picard.jar, CollectWgsMetrics]
 arguments:
   - position: 1


### PR DESCRIPTION
	modified:   picard_collectrawwgsmetrics.cwl
	modified:   picard_collectwgsmetrics.cwl

change these two QC step picard version to 2.15.0

version 2.8.3 do not have option USE_FAST_ALGORITHM